### PR TITLE
Allow running DigitalOcean setup script as root

### DIFF
--- a/digital_ocean_setup.sh
+++ b/digital_ocean_setup.sh
@@ -34,10 +34,11 @@ print_header() {
     echo -e "${BLUE}[STEP]${NC} $1"
 }
 
-# Check if running as root
+# Check user privileges
 if [[ $EUID -eq 0 ]]; then
-   print_error "This script should not be run as root. Please run as a regular user with sudo privileges."
-   exit 1
+   print_warning "Running as root. Proceeding with elevated privileges."
+else
+   print_status "Running as non-root user. Sudo will be used for required commands."
 fi
 
 # Update system


### PR DESCRIPTION
## Summary
- Adjust setup script to permit execution as root while still supporting non-root users.
- Display a warning when running as root and an informational message for non-root users.

## Testing
- `bash -n digital_ocean_setup.sh`


------
https://chatgpt.com/codex/tasks/task_e_68be4d9b15d0832e9aa4d54fb1cc1cd7