### PR TITLE
Add gradient accumulation steps option

### DIFF
--- a/MVLM_TRAINING_COMPLETE_GUIDE.md
+++ b/MVLM_TRAINING_COMPLETE_GUIDE.md
@@ -148,7 +148,8 @@ python mvlm_trainer.py \
     --batch_size 8 \
     --learning_rate 5e-5 \
     --num_epochs 3 \
-    --max_length 512
+    --max_length 512 \
+    --gradient_accumulation_steps 1
 ```
 
 ### Step 3.2: Monitor Training Progress

--- a/digital_ocean_gpu_guide.md
+++ b/digital_ocean_gpu_guide.md
@@ -138,6 +138,8 @@ sudo reboot
 ```bash
 # Reduce batch size in training script
 python mvlm_trainer.py --batch_size 4
+# Or use gradient accumulation
+python mvlm_trainer.py --batch_size 4 --gradient_accumulation_steps 2
 ```
 
 #### 3. Dataset Not Found

--- a/digital_ocean_setup.sh
+++ b/digital_ocean_setup.sh
@@ -210,7 +210,7 @@ fi
 
 echo ""
 echo "To start training, run:"
-echo "python mvlm_trainer.py --data_dir data/mvlm_comprehensive_dataset"
+echo "python mvlm_trainer.py --data_dir data/mvlm_comprehensive_dataset --gradient_accumulation_steps 1"
 echo ""
 EOF
 
@@ -254,7 +254,8 @@ python mvlm_trainer.py \
     --batch_size 8 \
     --learning_rate 5e-5 \
     --num_epochs 3 \
-    --max_length 512
+    --max_length 512 \
+    --gradient_accumulation_steps 1
 
 echo ""
 echo "Training completed!"


### PR DESCRIPTION
## Summary
- support gradient accumulation in `mvlm_trainer.py` with new `--gradient_accumulation_steps` argument and accumulation logic
- document gradient accumulation usage in training guides and setup script

## Testing
- `python -m py_compile mvlm_trainer.py`
- `bash -n digital_ocean_setup.sh`
- `pytest` *(no tests discovered)*
- `python mvlm_trainer.py --help` *(fails: ModuleNotFoundError: No module named 'torch')*


------
https://chatgpt.com/codex/tasks/task_e_68be4d9fd2d0832e872f36d05b0df5be