### PR TITLE
Add weighted text dataset using Prioritary tokenizer

### DIFF
--- a/data/weighted_text_dataset.py
+++ b/data/weighted_text_dataset.py
@@ -1,0 +1,56 @@
+import json
+from pathlib import Path
+from typing import Dict, List, TYPE_CHECKING
+
+import torch
+from torch.utils.data import Dataset
+
+if TYPE_CHECKING:
+    from prioritary_tokenizer import PrioritaryTokenizer
+    from prioritary_config import PrioritaryConfig
+
+
+class WeightedTextDataset(Dataset):
+    """Dataset class for training with prioritized weighting."""
+
+    def __init__(self, data_dir: str, tokenizer: 'PrioritaryTokenizer', config: 'PrioritaryConfig'):
+        self.tokenizer = tokenizer
+        self.max_length = config.max_length
+        self.stride = config.stride
+        self.examples: List[torch.Tensor] = []
+        self.metadata: List[Dict] = []
+
+        data_path = Path(data_dir)
+        for txt_file in data_path.rglob("*.txt"):
+            json_file = txt_file.with_suffix('.json')
+            if json_file.exists():
+                with open(json_file, 'r') as f:
+                    metadata = json.load(f)
+            else:
+                metadata = {'quality_score': 8.0, 'biblical_alignment': 7.0}
+            try:
+                with open(txt_file, 'r', encoding='utf-8') as f:
+                    text = f.read()
+                self._process_text(text, metadata)
+            except Exception:
+                continue
+
+    def _process_text(self, text: str, metadata: Dict):
+        tokens = self.tokenizer.encode(text, add_special_tokens=True)
+        for i in range(0, len(tokens) - self.max_length + 1, self.stride):
+            example_tokens = tokens[i:i + self.max_length]
+            if len(example_tokens) < self.max_length:
+                example_tokens.extend([self.tokenizer.pad_token_id] * (self.max_length - len(example_tokens)))
+            self.examples.append(torch.tensor(example_tokens, dtype=torch.long))
+            self.metadata.append(metadata)
+
+    def __len__(self) -> int:
+        return len(self.examples)
+
+    def __getitem__(self, idx: int) -> Dict:
+        tensor = self.examples[idx]
+        return {
+            'input_ids': tensor,
+            'labels': tensor.clone(),
+            'metadata': self.metadata[idx]
+        }


### PR DESCRIPTION
## Summary
- add `WeightedTextDataset` mirroring existing dataset logic using `PrioritaryTokenizer`
- read `max_length` and `stride` from `PrioritaryConfig`

## Testing
- `python -m py_compile data/weighted_text_dataset.py`


------
https://chatgpt.com/codex/tasks/task_e_68bf0c4c26a0832e9f5a8ad3bf748bd4