### PR TITLE
Switch to BPE tokenizer and adjust vocabulary size

### DIFF
--- a/SIM-ONE Training/prioritary_mvlm/config.py
+++ b/SIM-ONE Training/prioritary_mvlm/config.py
@@ -25,7 +25,7 @@ class PrioritaryConfig:
         Stride when creating training windows.
     """
 
-    vocab_size: int = 131
+    vocab_size: int = 8000
     hidden_dim: int = 512
     num_heads: int = 8
     ff_dim: int = 2048

--- a/SIM-ONE Training/prioritary_mvlm/tokenizer.py
+++ b/SIM-ONE Training/prioritary_mvlm/tokenizer.py
@@ -1,29 +1,12 @@
-class PrioritaryTokenizer:
-    """Simple character-level tokenizer for SIM-ONE."""
+"""Subword tokenizer for SIM-ONE models.
 
-    def __init__(self):
-        self.pad_token_id = 0
-        self.bos_token_id = 1
-        self.eos_token_id = 2
-        self.offset = 3
-        self.vocab_size = 128 + self.offset
+This module re-uses the repository's shared :class:`PrioritaryTokenizer`
+implementation which is based on a pretrained BPE tokenizer stored under
+``tokenization/prioritary_tokenizer``.  The tokenizer provides special token
+IDs and an interface compatible with the training utilities.
+"""
 
-    def encode(self, text, add_special_tokens=True):
-        ids = []
-        if add_special_tokens:
-            ids.append(self.bos_token_id)
-        for ch in text:
-            ids.append(ord(ch) % 128 + self.offset)
-        if add_special_tokens:
-            ids.append(self.eos_token_id)
-        return ids
+from tokenization import PrioritaryTokenizer as PrioritaryTokenizer  # re-export
 
-    def decode(self, ids):
-        chars = []
-        for i in ids:
-            if i >= self.offset:
-                chars.append(chr((i - self.offset) % 128))
-        return ''.join(chars)
+__all__ = ["PrioritaryTokenizer"]
 
-    def __len__(self):
-        return self.vocab_size

--- a/models/prioritary_mvlm.py
+++ b/models/prioritary_mvlm.py
@@ -12,7 +12,7 @@ from torch import Tensor
 class PrioritaryConfig:
     """Configuration for :class:`PrioritaryMVLM`."""
 
-    vocab_size: int = 50257
+    vocab_size: int = 8000
     max_position_embeddings: int = 512
     hidden_size: int = 256
     num_hidden_layers: int = 4

--- a/prioritary_mvlm/config.py
+++ b/prioritary_mvlm/config.py
@@ -23,7 +23,7 @@ class PrioritaryConfig:
         Stride used when creating training windows from long texts.
     """
 
-    vocab_size: int = 50257
+    vocab_size: int = 8000
     n_layer: int = 4
     n_head: int = 8
     n_embd: int = 256

--- a/prioritary_mvlm/tokenizer.py
+++ b/prioritary_mvlm/tokenizer.py
@@ -1,5 +1,12 @@
-from transformers import GPT2Tokenizer
+"""Tokenizer wrapper for Prioritary MVLM models.
 
-class PrioritaryTokenizer(GPT2Tokenizer):
-    """Tokenizer wrapper for Prioritary MVLM."""
-    pass
+This module re-exports the :class:`PrioritaryTokenizer` defined in the
+``tokenization`` package.  The tokenizer is based on a pretrained
+subword/BPE vocabulary stored in ``tokenization/prioritary_tokenizer`` and
+provides a small interface compatible with the training utilities.
+"""
+
+from tokenization import PrioritaryTokenizer as PrioritaryTokenizer  # re-export
+
+__all__ = ["PrioritaryTokenizer"]
+

--- a/tokenization/__init__.py
+++ b/tokenization/__init__.py
@@ -11,6 +11,12 @@ from tokenizers import Tokenizer
 class PrioritaryTokenizer:
     """Simple wrapper around a tokenizer trained for MVLM.
 
+    This wrapper exposes a small, :class:`transformers`-like interface so it can
+    be used by the training utilities without pulling in the full Transformers
+    dependency.  Special token IDs follow the convention used when the
+    tokenizer was trained: ``[PAD]``=0, ``[UNK]``=1, ``[CLS]``=2 and
+    ``[SEP]``=3.
+
     Parameters
     ----------
     tokenizer_path: str or Path, optional
@@ -24,13 +30,26 @@ class PrioritaryTokenizer:
             tokenizer_path = base_dir / "prioritary_tokenizer" / "tokenizer.json"
         self._tokenizer = Tokenizer.from_file(str(tokenizer_path))
 
-    def encode(self, text: str) -> list[int]:
-        """Tokenize *text* and return a list of token ids."""
-        return self._tokenizer.encode(text).ids
+        # Special token identifiers
+        self.pad_token_id = 0
+        self.unk_token_id = 1
+        self.bos_token_id = 2
+        self.eos_token_id = 3
 
-    def decode(self, ids: list[int]) -> str:
+    def __len__(self) -> int:
+        """Return the size of the tokenizer vocabulary."""
+        return self._tokenizer.get_vocab_size()
+
+    def encode(self, text: str, add_special_tokens: bool = True) -> list[int]:
+        """Tokenize *text* and return a list of token ids."""
+        ids = self._tokenizer.encode(text).ids
+        if add_special_tokens:
+            ids = [self.bos_token_id] + ids + [self.eos_token_id]
+        return ids
+
+    def decode(self, ids: list[int], skip_special_tokens: bool = True) -> str:
         """Decode a sequence of token *ids* back into text."""
-        return self._tokenizer.decode(ids)
+        return self._tokenizer.decode(ids, skip_special_tokens=skip_special_tokens)
 
 
 __all__ = ["PrioritaryTokenizer"]


### PR DESCRIPTION
## Summary
- replace modulo-128 tokenizer with shared BPE implementation
- expose special token ids in tokenizer and update trainer to use them
- set `PrioritaryConfig.vocab_size` to 8000 and propagate to models

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68bf4a6f7784832e80ac5456c03fe810