### PR TITLE
Collect governance trace tensor for loss

### DIFF
--- a/SIM-ONE Training/prioritary_mvlm/enhanced_trainer.py
+++ b/SIM-ONE Training/prioritary_mvlm/enhanced_trainer.py
@@ -291,12 +291,22 @@ class EnhancedPrioritaryTrainer:
                     'batch_metadata': batch.get('metadata', {}),
                     'prophetic_state': prophetic_state
                 }
+                if isinstance(governance_outputs, dict) and 'trace_metadata' in governance_outputs:
+                    metadata['trace_metadata'] = governance_outputs['trace_metadata']
+
+                trace_tensor = None
+                if isinstance(governance_outputs, dict):
+                    trace_tensor = governance_outputs.get('trace')
+                if not isinstance(trace_tensor, torch.Tensor):
+                    raise ValueError(
+                        "Governance outputs must include a trace tensor for enhanced loss computation."
+                    )
 
                 # Compute comprehensive loss
                 total_loss, loss_components = self.loss_function(
                     logits=logits,
                     labels=labels,
-                    hidden_states=governance_outputs.get('trace', logits),  # Use trace or logits
+                    hidden_states=trace_tensor,
                     governance_outputs=governance_outputs,
                     metadata=metadata,
                     prophetic_state=prophetic_state
@@ -313,11 +323,21 @@ class EnhancedPrioritaryTrainer:
                 'batch_metadata': batch.get('metadata', {}),
                 'prophetic_state': prophetic_state
             }
+            if isinstance(governance_outputs, dict) and 'trace_metadata' in governance_outputs:
+                metadata['trace_metadata'] = governance_outputs['trace_metadata']
+
+            trace_tensor = None
+            if isinstance(governance_outputs, dict):
+                trace_tensor = governance_outputs.get('trace')
+            if not isinstance(trace_tensor, torch.Tensor):
+                raise ValueError(
+                    "Governance outputs must include a trace tensor for enhanced loss computation."
+                )
 
             total_loss, loss_components = self.loss_function(
                 logits=logits,
                 labels=labels,
-                hidden_states=governance_outputs.get('trace', logits),
+                hidden_states=trace_tensor,
                 governance_outputs=governance_outputs,
                 metadata=metadata,
                 prophetic_state=prophetic_state


### PR DESCRIPTION
## Summary
- project TraceGenerator outputs into a hidden-dimension tensor alongside existing trace metadata
- aggregate per-layer trace tensors in GovernanceAggregator and expose them with supporting metadata
- require the trace tensor for ComprehensiveBiblicalLoss and forward its metadata from the trainer

## Testing
- python -m compileall "SIM-ONE Training"

------
https://chatgpt.com/codex/tasks/task_e_68cb567302c4832eb398e30ce6b61e4e

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Richer, gated trace generation with concept-aware projection for more informative signals.
  - Aggregated trace outputs now include combined and per-layer traces with automatic cross-layer alignment.
  - Trace metadata is collected and surfaced alongside trace outputs when available.
- Bug Fixes
  - Stricter validation of trace inputs with clear error messages to avoid silent fallbacks.
- Refactor
  - Unified, consistent trace handling across model, aggregation, and training paths with no public API changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->