### PR TITLE
Adjust language modeling labels and pad handling

### DIFF
--- a/SIM-ONE Training/prioritary_mvlm/dataset.py
+++ b/SIM-ONE Training/prioritary_mvlm/dataset.py
@@ -99,7 +99,11 @@ class WeightedTextDataset(Dataset):
             labels[:-1] = tensor[1:]
 
         pad_token_id = getattr(self.tokenizer, 'pad_token_id', None)
-        pad_value = pad_token_id if pad_token_id is not None else -100
+        eos_token_id = getattr(self.tokenizer, 'eos_token_id', None)
+
+        pad_value = -100
+        if pad_token_id is not None and pad_token_id != eos_token_id:
+            pad_value = pad_token_id
 
         if seq_len <= 1:
             labels.fill_(pad_value)

--- a/SIM-ONE Training/prioritary_mvlm/enhanced_trainer.py
+++ b/SIM-ONE Training/prioritary_mvlm/enhanced_trainer.py
@@ -105,7 +105,8 @@ class EnhancedPrioritaryTrainer:
                 'policy': 0.1,
                 'memory': 0.1,
                 'energy': 0.05
-            }
+            },
+            pad_token_id=self.tokenizer.pad_token_id
         ).to(self.device)
         
         # Training state

--- a/SIM-ONE Training/prioritary_mvlm/enhanced_trainer.py
+++ b/SIM-ONE Training/prioritary_mvlm/enhanced_trainer.py
@@ -93,6 +93,10 @@ class EnhancedPrioritaryTrainer:
         self.optimizer, self.scheduler = self._setup_optimization()
         
         # Initialize loss function
+        pad_token_id = getattr(self.tokenizer, "pad_token_id", None)
+        eos_token_id = getattr(self.tokenizer, "eos_token_id", None)
+        ignore_idx = None if pad_token_id is None or pad_token_id == eos_token_id else pad_token_id
+
         self.loss_function = ComprehensiveBiblicalLoss(
             vocab_size=len(self.tokenizer),
             hidden_dim=self.config.hidden_dim,
@@ -106,7 +110,7 @@ class EnhancedPrioritaryTrainer:
                 'memory': 0.1,
                 'energy': 0.05
             },
-            pad_token_id=self.tokenizer.pad_token_id
+            pad_token_id=ignore_idx
         ).to(self.device)
         
         # Training state

--- a/SIM-ONE Training/prioritary_mvlm/trainer.py
+++ b/SIM-ONE Training/prioritary_mvlm/trainer.py
@@ -92,13 +92,20 @@ class PrioritaryTrainer:
         shifted_logits = logits[:, :-1, :].contiguous()
         shifted_labels = labels[:, :-1].contiguous()
 
+        pad_token_id = getattr(self.tokenizer, "pad_token_id", None)
+        eos_token_id = getattr(self.tokenizer, "eos_token_id", None)
+        if pad_token_id is None or pad_token_id == eos_token_id:
+            ignore_index = -100
+        else:
+            ignore_index = pad_token_id
+
         if shifted_logits.size(1) == 0:
             mle_loss = logits.sum() * 0.0
         else:
             mle_loss = F.cross_entropy(
                 shifted_logits.view(-1, vocab_size),
                 shifted_labels.view(-1),
-                ignore_index=self.tokenizer.pad_token_id,
+                ignore_index=ignore_index,
             )
         policy_loss = compute_policy_loss(aux["policy_logits"][-1])
         memory_loss = compute_memory_loss(aux["memory_signals"][-1])

--- a/SIM-ONE Training/prioritary_mvlm/trainer.py
+++ b/SIM-ONE Training/prioritary_mvlm/trainer.py
@@ -88,7 +88,18 @@ class PrioritaryTrainer:
 
         logits, aux = self.model(input_ids)
         vocab_size = len(self.tokenizer)
-        mle_loss = F.cross_entropy(logits.view(-1, vocab_size), labels.view(-1))
+
+        shifted_logits = logits[:, :-1, :].contiguous()
+        shifted_labels = labels[:, :-1].contiguous()
+
+        if shifted_logits.size(1) == 0:
+            mle_loss = logits.sum() * 0.0
+        else:
+            mle_loss = F.cross_entropy(
+                shifted_logits.view(-1, vocab_size),
+                shifted_labels.view(-1),
+                ignore_index=self.tokenizer.pad_token_id,
+            )
         policy_loss = compute_policy_loss(aux["policy_logits"][-1])
         memory_loss = compute_memory_loss(aux["memory_signals"][-1])
         energy_loss = compute_energy_loss(logits)


### PR DESCRIPTION
## Summary
- shift dataset labels one step to align next-token targets and mark padded positions
- update both trainers to compute cross-entropy on shifted logits while ignoring the tokenizer pad token id
- allow the comprehensive biblical loss to receive the pad id and apply the same masking, wiring the value through the enhanced trainer

## Testing
- python -m compileall mvlm_trainer.py 'SIM-ONE Training/prioritary_mvlm'

------
https://chatgpt.com/codex/tasks/task_e_68cb5de518a4832ea2cb72a08cedeee5

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Added support for custom padding tokens during training, improving compatibility with different tokenizers.
- Bug Fixes
  - Fixed training crashes on very short sequences by safely handling edge cases.
  - Correctly ignores padding in loss calculations, preventing inflated errors and unstable updates.
- Refactor
  - Aligned loss computation to next-token prediction semantics for greater training stability and consistent metrics.
  - Introduced per-example sequence length awareness to ensure accurate labeling and padding across datasets.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->