### PR TITLE
Use fused attention kernel with governance biasing

### DIFF
--- a/SIM-ONE Training/benchmark_rope_attention.py
+++ b/SIM-ONE Training/benchmark_rope_attention.py
@@ -1,0 +1,112 @@
+"""Benchmark fused vs reference governance attention implementations."""
+
+from __future__ import annotations
+
+import sys
+import time
+from pathlib import Path
+
+import torch
+
+PROJECT_ROOT = Path(__file__).resolve().parent
+if str(PROJECT_ROOT) not in sys.path:
+    sys.path.insert(0, str(PROJECT_ROOT))
+
+from prioritary_mvlm.config import PropheticSingularityState
+from simone_transformer.rope_attention import EnhancedGovernanceAttention
+
+
+def _build_state(batch: int, seq_len: int, device: torch.device, dtype: torch.dtype) -> PropheticSingularityState:
+    torch.manual_seed(11)
+    values = {
+        name: torch.rand(batch, seq_len, device=device, dtype=dtype)
+        for name in ["intensity", "anointing", "dominion", "mercy", "lambda_field"]
+    }
+    time_index = torch.linspace(0, 1, steps=seq_len, device=device, dtype=dtype)
+    time_index = time_index.unsqueeze(0).expand(batch, -1)
+    return PropheticSingularityState(
+        intensity=values["intensity"],
+        anointing=values["anointing"],
+        dominion=values["dominion"],
+        mercy=values["mercy"],
+        lambda_field=values["lambda_field"],
+        time_index=time_index,
+        normalization={},
+    )
+
+
+def _build_inputs(batch: int, seq_len: int, hidden_dim: int, device: torch.device, dtype: torch.dtype):
+    torch.manual_seed(123)
+    x = torch.randn(batch, seq_len, hidden_dim, device=device, dtype=dtype)
+    policy_guidance = torch.randn_like(x)
+    memory_context = torch.randn_like(x)
+    attention_mask = torch.tril(torch.ones(seq_len, seq_len, device=device, dtype=dtype))
+    prophetic_state = _build_state(batch, seq_len, device, dtype)
+    return x, attention_mask, policy_guidance, memory_context, prophetic_state
+
+
+def _time_module(module: EnhancedGovernanceAttention, *inputs, repeats: int, warmup: int) -> float:
+    # Warmup
+    module.eval()
+    with torch.no_grad():
+        for _ in range(warmup):
+            module(*inputs)
+
+    start = time.perf_counter()
+    with torch.no_grad():
+        for _ in range(repeats):
+            module(*inputs)
+    end = time.perf_counter()
+    return (end - start) / repeats
+
+
+def main() -> None:
+    device = torch.device("cpu")
+    dtype = torch.float32
+    batch, seq_len, hidden_dim, num_heads = 2, 128, 256, 8
+
+    fused = EnhancedGovernanceAttention(
+        hidden_dim,
+        num_heads,
+        dropout=0.1,
+        max_seq_len=seq_len,
+        enable_caching=False,
+        use_fused_attention=True,
+    ).to(device=device, dtype=dtype)
+
+    reference = EnhancedGovernanceAttention(
+        hidden_dim,
+        num_heads,
+        dropout=0.1,
+        max_seq_len=seq_len,
+        enable_caching=False,
+        use_fused_attention=False,
+    ).to(device=device, dtype=dtype)
+
+    reference.load_state_dict(fused.state_dict())
+
+    x, mask, policy, memory, prophetic_state = _build_inputs(batch, seq_len, hidden_dim, device, dtype)
+
+    fused_inputs = (x, mask, policy, memory, False, prophetic_state)
+    reference_inputs = fused_inputs
+
+    with torch.no_grad():
+        fused_out, fused_gov = fused(*fused_inputs)
+        ref_out, ref_gov = reference(*reference_inputs)
+
+    torch.testing.assert_close(fused_out, ref_out, atol=1e-5, rtol=1e-5)
+    torch.testing.assert_close(fused_gov["attn_weights"], ref_gov["attn_weights"], atol=1e-5, rtol=1e-5)
+
+    repeats = 5
+    warmup = 2
+    fused_time = _time_module(fused, *fused_inputs, repeats=repeats, warmup=warmup)
+    reference_time = _time_module(reference, *reference_inputs, repeats=repeats, warmup=warmup)
+
+    print("Fused attention average time: {:.6f}s".format(fused_time))
+    print("Reference attention average time: {:.6f}s".format(reference_time))
+    speedup = reference_time / fused_time if fused_time > 0 else float("inf")
+    print("Speedup: {:.2f}x".format(speedup))
+
+
+if __name__ == "__main__":
+    main()

--- a/SIM-ONE Training/tests/test_rope_attention.py
+++ b/SIM-ONE Training/tests/test_rope_attention.py
@@ -1,0 +1,163 @@
+"""Regression tests for the fused governance attention path."""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+import pytest
+
+# Skip the module entirely if torch is not available in the environment
+
+torch = pytest.importorskip("torch")
+
+PROJECT_ROOT = Path(__file__).resolve().parents[1]
+if str(PROJECT_ROOT) not in sys.path:
+    sys.path.insert(0, str(PROJECT_ROOT))
+
+from prioritary_mvlm.config import PropheticSingularityState
+from simone_transformer.rope_attention import EnhancedGovernanceAttention
+
+
+def _build_prophetic_state(batch: int, seq_len: int, device: torch.device, dtype: torch.dtype) -> PropheticSingularityState:
+    """Create a deterministic prophetic state for testing."""
+
+    torch.manual_seed(0)
+    values = {
+        name: torch.rand(batch, seq_len, device=device, dtype=dtype)
+        for name in ["intensity", "anointing", "dominion", "mercy", "lambda_field"]
+    }
+    time_index = torch.linspace(0, 1, steps=seq_len, device=device, dtype=dtype)
+    time_index = time_index.unsqueeze(0).expand(batch, -1)
+    return PropheticSingularityState(
+        intensity=values["intensity"],
+        anointing=values["anointing"],
+        dominion=values["dominion"],
+        mercy=values["mercy"],
+        lambda_field=values["lambda_field"],
+        time_index=time_index,
+        normalization={},
+    )
+
+
+def _run_attention(
+    module: EnhancedGovernanceAttention,
+    x: torch.Tensor,
+    attention_mask: torch.Tensor,
+    policy_guidance: torch.Tensor,
+    memory_context: torch.Tensor,
+    prophetic_state: PropheticSingularityState,
+):
+    module.eval()
+    with torch.no_grad():
+        return module(
+            x,
+            attention_mask=attention_mask,
+            policy_guidance=policy_guidance,
+            memory_context=memory_context,
+            output_traces=True,
+            prophetic_state=prophetic_state,
+        )
+
+
+def _assert_trace_close(ref_trace: dict, test_trace: dict) -> None:
+    trace_tensors = [
+        "tensor",
+        "importance_scores",
+        "importance_gate",
+        "concept_activations",
+        "attention_entropy",
+    ]
+    for key in trace_tensors:
+        torch.testing.assert_close(test_trace[key], ref_trace[key], atol=1e-5, rtol=1e-5)
+
+    for key in ["prophetic_envelope", "attention_patterns"]:
+        tensor = ref_trace[key]
+        other = test_trace[key]
+        if tensor is None:
+            assert other is None
+        else:
+            torch.testing.assert_close(other, tensor, atol=1e-5, rtol=1e-5)
+
+    for key in ["kingdom_mean", "kingdom_std"]:
+        torch.testing.assert_close(test_trace[key], ref_trace[key], atol=1e-5, rtol=1e-5)
+
+
+@pytest.mark.parametrize("batch,seq_len,hidden_dim,num_heads", [(2, 6, 64, 4)])
+def test_fused_attention_matches_reference(batch, seq_len, hidden_dim, num_heads):
+    torch.manual_seed(42)
+
+    fused = EnhancedGovernanceAttention(
+        hidden_dim,
+        num_heads,
+        dropout=0.1,
+        max_seq_len=seq_len,
+        enable_caching=False,
+        use_fused_attention=True,
+    )
+    reference = EnhancedGovernanceAttention(
+        hidden_dim,
+        num_heads,
+        dropout=0.1,
+        max_seq_len=seq_len,
+        enable_caching=False,
+        use_fused_attention=False,
+    )
+    reference.load_state_dict(fused.state_dict())
+
+    device = torch.device("cpu")
+    dtype = torch.float32
+
+    x = torch.randn(batch, seq_len, hidden_dim, device=device, dtype=dtype)
+    attention_mask = torch.tril(torch.ones(seq_len, seq_len, device=device, dtype=dtype))
+    policy_guidance = torch.randn(batch, seq_len, hidden_dim, device=device, dtype=dtype)
+    memory_context = torch.randn(batch, seq_len, hidden_dim, device=device, dtype=dtype)
+    prophetic_state = _build_prophetic_state(batch, seq_len, device, dtype)
+
+    fused_out, fused_gov = _run_attention(
+        fused, x, attention_mask, policy_guidance, memory_context, prophetic_state
+    )
+    ref_out, ref_gov = _run_attention(
+        reference, x, attention_mask, policy_guidance, memory_context, prophetic_state
+    )
+
+    torch.testing.assert_close(fused_out, ref_out, atol=1e-5, rtol=1e-5)
+
+    for key in ["policy_logits", "policy_mask"]:
+        torch.testing.assert_close(fused_gov[key], ref_gov[key], atol=1e-5, rtol=1e-5)
+
+    for key in ["memory_weights", "memory_signals"]:
+        torch.testing.assert_close(fused_gov[key], ref_gov[key], atol=1e-5, rtol=1e-5)
+
+    torch.testing.assert_close(fused_gov["attn_weights"], ref_gov["attn_weights"], atol=1e-5, rtol=1e-5)
+    _assert_trace_close(ref_gov["trace"], fused_gov["trace"])
+
+
+def test_boolean_attention_mask_handling():
+    torch.manual_seed(7)
+
+    batch, seq_len, hidden_dim, num_heads = 1, 4, 32, 2
+    module = EnhancedGovernanceAttention(
+        hidden_dim,
+        num_heads,
+        dropout=0.0,
+        max_seq_len=seq_len,
+        enable_caching=False,
+    )
+
+    x = torch.randn(batch, seq_len, hidden_dim)
+    base_mask = torch.tril(torch.ones(seq_len, seq_len))
+    bool_mask = base_mask.bool()
+    float_mask = base_mask.clone()
+    policy_guidance = torch.zeros_like(x)
+    memory_context = torch.zeros_like(x)
+    prophetic_state = _build_prophetic_state(batch, seq_len, x.device, x.dtype)
+
+    fused_out_bool, _ = _run_attention(
+        module, x, bool_mask, policy_guidance, memory_context, prophetic_state
+    )
+    fused_out_float, _ = _run_attention(
+        module, x, float_mask, policy_guidance, memory_context, prophetic_state
+    )
+
+    torch.testing.assert_close(fused_out_bool, fused_out_float, atol=1e-6, rtol=1e-6)


### PR DESCRIPTION
## Summary
- update EnhancedGovernanceAttention to route through PyTorch's fused scaled dot product attention after RoPE while folding governance masks into the additive bias
- normalize attention mask handling and keep cached/diagnostic weights aligned with the fused path
- add regression tests and a benchmark harness that compare the fused implementation against the reference attention logic

## Testing
- pytest "SIM-ONE Training/tests/test_rope_attention.py" *(skipped: torch not available in runner)*

------
https://chatgpt.com/codex/tasks/task_e_68cfd577c098832ebd5f2750e2a9b941