### PR TITLE
Ensure WeightedTextDataset handles short documents

### DIFF
--- a/SIM-ONE Training/prioritary_mvlm/dataset.py
+++ b/SIM-ONE Training/prioritary_mvlm/dataset.py
@@ -40,14 +40,39 @@ class WeightedTextDataset(Dataset):
 
     def _process_text(self, text: str, metadata: Dict):
         tokens = self.tokenizer.encode(text, add_special_tokens=True)
-        for i in range(0, len(tokens) - self.max_length + 1, self.stride):
-            example_tokens = tokens[i:i + self.max_length]
-            sequence_length = len(example_tokens)
-            if len(example_tokens) < self.max_length:
-                example_tokens.extend([self.tokenizer.pad_token_id] * (self.max_length - len(example_tokens)))
-            self.examples.append(torch.tensor(example_tokens, dtype=torch.long))
+        if not tokens:
+            return
+
+        pad_token_id = self.tokenizer.pad_token_id
+
+        def append_window(window_tokens: List[int]) -> None:
+            tokens_list = list(window_tokens)
+            if not tokens_list:
+                return
+
+            sequence_length = min(len(tokens_list), self.max_length)
+            tokens_list = tokens_list[:self.max_length]
+
+            if sequence_length < self.max_length:
+                tokens_list.extend([pad_token_id] * (self.max_length - sequence_length))
+
+            self.examples.append(torch.tensor(tokens_list, dtype=torch.long))
             self.metadata.append(metadata)
             self.sequence_lengths.append(sequence_length)
+
+        if len(tokens) <= self.max_length:
+            append_window(tokens)
+            return
+
+        last_start = None
+        limit = len(tokens) - self.max_length + 1
+        for start in range(0, limit, self.stride):
+            append_window(tokens[start:start + self.max_length])
+            last_start = start
+
+        final_start = max(len(tokens) - self.max_length, 0)
+        if last_start is None or final_start > last_start:
+            append_window(tokens[final_start:])
 
     def _build_prophetic_state(self, metadata: Dict) -> PropheticSingularityState:
         return PropheticSingularityState.from_metadata(metadata, self.max_length)

--- a/SIM-ONE Training/prioritary_mvlm/dataset.py
+++ b/SIM-ONE Training/prioritary_mvlm/dataset.py
@@ -43,7 +43,12 @@ class WeightedTextDataset(Dataset):
         if not tokens:
             return
 
-        pad_token_id = self.tokenizer.pad_token_id
+        pad_token_id = getattr(self.tokenizer, 'pad_token_id', None)
+        if pad_token_id is None:
+            raise ValueError(
+                "Tokenizer must define pad_token_id to enable window padding. "
+                "Set tokenizer.pad_token_id or use a tokenizer that provides one."
+            )
 
         def append_window(window_tokens: List[int]) -> None:
             tokens_list = list(window_tokens)
@@ -66,6 +71,8 @@ class WeightedTextDataset(Dataset):
 
         last_start = None
         limit = len(tokens) - self.max_length + 1
+        if not isinstance(self.stride, int) or self.stride <= 0:
+            raise ValueError(f"stride must be a positive int; got {self.stride!r}")
         for start in range(0, limit, self.stride):
             append_window(tokens[start:start + self.max_length])
             last_start = start

--- a/tests/test_dataset.py
+++ b/tests/test_dataset.py
@@ -1,0 +1,42 @@
+import json
+import sys
+from pathlib import Path
+
+import pytest
+
+pytest.importorskip("torch")
+_SIM_ONE_PATH = Path(__file__).resolve().parents[1] / "SIM-ONE Training"
+if str(_SIM_ONE_PATH) not in sys.path:
+    sys.path.append(str(_SIM_ONE_PATH))
+
+from prioritary_mvlm.config import PrioritaryConfig
+from prioritary_mvlm.dataset import WeightedTextDataset
+from prioritary_mvlm.tokenizer import PrioritaryTokenizer
+
+
+def test_short_text_is_padded_and_preserves_eos_label(tmp_path: Path) -> None:
+    data_dir = tmp_path / "data"
+    data_dir.mkdir()
+
+    (data_dir / "sample.txt").write_text("Hello", encoding="utf-8")
+    (data_dir / "sample.json").write_text(json.dumps({"id": 1}), encoding="utf-8")
+
+    tokenizer = PrioritaryTokenizer()
+    config = PrioritaryConfig(max_length=8, stride=4)
+    dataset = WeightedTextDataset(str(data_dir), tokenizer, config)
+
+    assert len(dataset) == 1
+
+    sample = dataset[0]
+    input_ids = sample["input_ids"].tolist()
+    labels = sample["labels"].tolist()
+
+    assert len(input_ids) == config.max_length
+
+    eos_index = input_ids.index(tokenizer.eos_token_id)
+    assert eos_index > 0
+
+    assert all(token == tokenizer.pad_token_id for token in input_ids[eos_index + 1 :])
+
+    assert labels[eos_index - 1] == tokenizer.eos_token_id
+    assert labels[eos_index] == tokenizer.pad_token_id


### PR DESCRIPTION
## Summary
- ensure `WeightedTextDataset` always produces at least one window per document, padding short sequences and adding a trailing slice for leftovers while tracking true lengths
- add a regression test covering short texts to confirm padding behaviour preserves the EOS label

## Testing
- `pytest tests/test_dataset.py` *(skipped: torch dependency unavailable in the environment)*

------
https://chatgpt.com/codex/tasks/task_e_68cfdaf5cba8832e8fe5ce3d13b306d9

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- Bug Fixes
  - Corrected end-of-sequence and padding handling for shorter sequences.
  - Added guard for empty inputs and ensured metadata stays aligned.
  - Fixed edge case to include the final sliding window.

- Refactor
  - Reworked sliding-window processing to produce fixed-length windows with explicit padding and consistent sequence-length tracking.

- Tests
  - Added unit tests validating windowing, padding, EOS placement, and label alignment.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->