### PR TITLE
Add validation dataloader support to enhanced trainer

### DIFF
--- a/H200_SETUP_README.md
+++ b/H200_SETUP_README.md
@@ -122,10 +122,15 @@ python3 mvlm_trainer.py \
 ```
 
 ### SIM-ONE Enhanced
+The enhanced SIM-ONE trainer now supports dedicated validation data. Point
+`--data_dir` at your training split and either specify `--validation_dir` for a
+separate validation folder or rely on the default `--validation_split` (10%
+holdout) when a dedicated directory is unavailable.
 ```bash
 cd "SIM-ONE Training"
 python3 enhanced_train.py \
-    --data_dir ../mvlm_training_dataset_complete \
+    --data_dir ../mvlm_training_dataset_complete/train \
+    --validation_dir ../mvlm_training_dataset_complete/val \
     --output_dir ../models/mvlm_simone_enhanced \
     --vocab_size 32000 \
     --batch_size 12 \

--- a/README.md
+++ b/README.md
@@ -162,7 +162,9 @@ python3 mvlm_trainer.py \
 # Train Enhanced SIM-ONE only
 cd "SIM-ONE Training"
 python3 enhanced_train.py \
-    --data_dir ../mvlm_training_dataset_complete \
+    # Provide --validation_dir when you have a dedicated validation set
+    --data_dir ../mvlm_training_dataset_complete/train \
+    --validation_dir ../mvlm_training_dataset_complete/val \
     --output_dir ../models/simone_enhanced \
     --vocab_size 32000 \
     --batch_size 12 \
@@ -302,7 +304,10 @@ export PYTORCH_CUDA_ALLOC_CONF=max_split_size_mb:256
 
 # Training Interrupted - Resume from checkpoint
 cd "SIM-ONE Training"
-python3 enhanced_train.py --resume_from best_model
+python3 enhanced_train.py \
+    --resume_from best_model \
+    --data_dir ../mvlm_training_dataset_complete/train \
+    --validation_dir ../mvlm_training_dataset_complete/val
 
 # Import/Path Issues
 # Ensure Python path includes repository root

--- a/SIM-ONE Training/README.md
+++ b/SIM-ONE Training/README.md
@@ -65,14 +65,17 @@ SIM-ONE Training/
 ## 🚀 Quick Start
 
 ### Basic Training
+The enhanced trainer will automatically reserve 10% of the dataset for
+validation when `--validation_dir` is not provided.
 ```bash
-python enhanced_train.py --data_dir ../mvlm_training_dataset_complete
+python enhanced_train.py --data_dir ../mvlm_training_dataset_complete --validation_split 0.1
 ```
 
 ### Advanced Training
 ```bash
 python enhanced_train.py \
-    --data_dir ../mvlm_training_dataset_complete \
+    --data_dir ../mvlm_training_dataset_complete/train \
+    --validation_dir ../mvlm_training_dataset_complete/val \
     --output_dir enhanced_checkpoints \
     --vocab_size 32000 \
     --hidden_dim 768 \
@@ -87,7 +90,8 @@ python enhanced_train.py \
 ```bash
 python enhanced_train.py \
     --resume_from checkpoint_step_5000 \
-    --data_dir ../mvlm_training_dataset_complete
+    --data_dir ../mvlm_training_dataset_complete/train \
+    --validation_dir ../mvlm_training_dataset_complete/val
 ```
 
 ## ⚙️ Configuration Options
@@ -106,6 +110,10 @@ python enhanced_train.py \
 - `--learning_rate`: Peak learning rate (default: 3e-4)
 - `--num_epochs`: Training epochs (default: 3)
 - `--warmup_steps`: Warmup steps (default: 2,000)
+- `--validation_split`: Fraction of data reserved for validation when no validation directory is provided (default: 0.1)
+
+### Data Management
+- `--validation_dir`: Path to a dedicated validation dataset. When set, overrides the holdout split.
 
 ### Advanced Features
 - `--no_mixed_precision`: Disable mixed precision

--- a/SIM-ONE Training/enhanced_train.py
+++ b/SIM-ONE Training/enhanced_train.py
@@ -44,7 +44,9 @@ def create_enhanced_config(args) -> PrioritaryConfig:
     config.gradient_accumulation_steps = args.gradient_accumulation_steps
     config.log_interval = 10
     config.eval_interval = 100
-    
+    config.validation_split = args.validation_split
+    config.validation_dir = args.validation_dir
+
     return config
 
 
@@ -56,14 +58,25 @@ def main():
     
     # Data and output
     parser.add_argument(
-        "--data_dir", 
-        type=str, 
+        "--data_dir",
+        type=str,
         default="../mvlm_training_dataset_complete",
         help="Directory containing training data"
     )
     parser.add_argument(
-        "--output_dir", 
-        type=str, 
+        "--validation_dir",
+        type=str,
+        help="Optional directory containing validation data (overrides validation_split)"
+    )
+    parser.add_argument(
+        "--validation_split",
+        type=float,
+        default=0.1,
+        help="Fraction of training data used for validation when no validation_dir is provided"
+    )
+    parser.add_argument(
+        "--output_dir",
+        type=str,
         default="enhanced_checkpoints",
         help="Directory to save trained model"
     )
@@ -111,6 +124,10 @@ def main():
     print("Enhanced SIM-ONE Transformer Training")
     print("=" * 50)
     print(f"Data directory: {args.data_dir}")
+    if args.validation_dir:
+        print(f"Validation directory: {args.validation_dir}")
+    else:
+        print(f"Validation split: {config.validation_split:.2f}")
     print(f"Output directory: {args.output_dir}")
     print(f"Vocabulary size: {config.vocab_size:,}")
     print(f"Model size: {config.num_layers}L-{config.hidden_dim}H-{config.num_heads}A")

--- a/SIM-ONE Training/prioritary_mvlm/config.py
+++ b/SIM-ONE Training/prioritary_mvlm/config.py
@@ -397,6 +397,10 @@ class PrioritaryConfig:
     gradient_accumulation_steps: int = 1
     log_interval: int = 10
     eval_interval: int = 100
+    validation_split: float = 0.1
+    validation_dir: Optional[str] = None
+    dataloader_workers: int = 4
+    split_seed: int = 42
     lambda_policy: float = 1.0
     lambda_memory: float = 1.0
     lambda_energy: float = 1.0


### PR DESCRIPTION
## Summary
- extend the enhanced trainer to build separate training and validation dataloaders, including optional directory-based splits or holdout ratios, and run evaluation on the validation loader
- surface validation split and directory options through the enhanced CLI/configuration and log the selected validation source
- document the expectation for providing validation data in the H200 setup guide and SIM-ONE training readmes

## Testing
- python -m compileall "SIM-ONE Training/prioritary_mvlm" "SIM-ONE Training/enhanced_train.py"

------
https://chatgpt.com/codex/tasks/task_e_68cfe005e04c832e812f41b6a7df1802

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Add validation support: use a dedicated validation directory (--validation_dir) or automatic split (--validation_split, default 0.1) with seed control.
  - Separate train/validation loaders with auto-detection of train/val folders; periodic validation metrics during training; clearer dataset/batch logging.
  - Configurable dataloader workers for performance tuning.

- Documentation
  - Updated guides and examples to include validation_dir/validation_split, new train/val paths, and resume workflows.
  - Added a Data Management section explaining validation options and when to use each.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->